### PR TITLE
Restrict parser to only add images from Doxygen XML with an HTML type

### DIFF
--- a/src/DoxyXmlParser.h
+++ b/src/DoxyXmlParser.h
@@ -127,9 +127,14 @@ public:
 		const char** attributes
 	) {
 		T* type = AXL_MEM_NEW(T);
-		TypeStackEntry entry = { type, 0 };
-		m_typeStack.append(entry);
-		return type->create(this, context, name, attributes);
+		if (type->create(this, context, name, attributes)) {
+			TypeStackEntry entry = { type, 0 };
+			m_typeStack.append(entry);
+			return true;
+		}
+		else {
+			return false;
+		}
 	}
 
 	Compound*

--- a/src/DoxyXmlType.cpp
+++ b/src/DoxyXmlType.cpp
@@ -1242,7 +1242,6 @@ DocImageType::create(
 	m_parser = parser;
 	m_imageBlock = AXL_MEM_NEW(DocImageBlock);
 	m_imageBlock->m_blockKind = name;
-	list->insertTail(m_imageBlock);
 
 	while (*attributes) {
 		AttrKind attrKind = AttrKindMap::findValue(attributes[0], AttrKind_Undefined);
@@ -1265,6 +1264,10 @@ DocImageType::create(
 		}
 
 		attributes += 2;
+	}
+
+	if (m_imageBlock->m_imageKind == ImageKind_Html) {
+		list->insertTail(m_imageBlock);
 	}
 
 	return true;


### PR DESCRIPTION
PS: sorry for the second user name.  I didn't realize which account I used to open the issue.

This pull request is in reference to: #51 

The open questions to me are:
1. Is my assumption about image tags applicable to all users?
2. Or should there be a configuration option to select a particular tag?
3. More broadly, should be apply to more than just images?